### PR TITLE
[OPS-7842] Remove the Snap debug override, which passes an empty var …

### DIFF
--- a/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/PrintSectionController.php
@@ -112,7 +112,6 @@ class PrintSectionController extends ControllerBase {
         $pdf_header .= '<style type="text/css">' . $css . '</style>';
       }
       $params  = [
-        'debug'          => (getenv("PHP_ENVIRONMENT") == "development") ? TRUE : FALSE,
         'logo'           => 'gms',
         'media'          => 'print',
         'output'         => 'pdf',

--- a/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
+++ b/html/modules/custom/gms_pdflink/src/Controller/ViewPdfController.php
@@ -106,7 +106,6 @@ class ViewPdfController extends ControllerBase {
         $pdf_header .= '<style type="text/css">' . $css . '</style>';
       }
       $params = [
-        'debug'          => (getenv("PHP_ENVIRONMENT") == "development") ? TRUE : FALSE,
         'logo'           => 'gms',
         'media'          => 'print',
         'output'         => 'pdf',


### PR DESCRIPTION
…on prod, and breaks PDFs. The module settings toggle works just fine.